### PR TITLE
Resolving skywater-pdk issues #297 and #298.

### DIFF
--- a/cells/dlxbn/sky130_fd_sc_hd__dlxbn.behavioral.pp.v
+++ b/cells/dlxbn/sky130_fd_sc_hd__dlxbn.behavioral.pp.v
@@ -61,7 +61,6 @@ module sky130_fd_sc_hd__dlxbn (
     wire D_delayed     ;
     reg  notifier      ;
     wire awake         ;
-    wire 1             ;
 
     //                                    Name     Output  Other arguments
     not                                   not0    (GATE  , GATE_N_delayed                       );

--- a/cells/dlxbn/sky130_fd_sc_hd__dlxbn.behavioral.v
+++ b/cells/dlxbn/sky130_fd_sc_hd__dlxbn.behavioral.v
@@ -59,7 +59,6 @@ module sky130_fd_sc_hd__dlxbn (
     wire D_delayed     ;
     reg  notifier      ;
     wire awake         ;
-    wire 1             ;
 
     //                                    Name     Output  Other arguments
     not                                   not0    (GATE  , GATE_N_delayed                       );

--- a/cells/lpflow_bleeder/sky130_fd_sc_hd__lpflow_bleeder.functional.v
+++ b/cells/lpflow_bleeder/sky130_fd_sc_hd__lpflow_bleeder.functional.v
@@ -33,4 +33,4 @@ endmodule
 `endcelldefine
 
 `default_nettype wire
-`endif SKY130_FD_SC_HD__LPFLOW_BLEEDER_FUNCTIONAL_V
+`endif // SKY130_FD_SC_HD__LPFLOW_BLEEDER_FUNCTIONAL_V


### PR DESCRIPTION
Corrected the dlxbn behavioral verilog (both files) to remove the incorrect
"wire 1" entries, per skywater-pdk issue #297.  Corrected the lpflow_bleeder
cell to add the required comment characters in front of the cellname after
"endif" in the functional.v verilog, per skywater-pdk issue #298.