### PR TITLE
Fixed the diode perimeter value in the diode_2 cell's SPICE netlist.

### DIFF
--- a/cells/diode/sky130_fd_sc_hd__diode_2.spice
+++ b/cells/diode/sky130_fd_sc_hd__diode_2.spice
@@ -16,5 +16,5 @@
 
 
 .subckt sky130_fd_sc_hd__diode_2 DIODE VGND VNB VPB VPWR
-D0 VNB DIODE sky130_fd_pr__diode_pw2nd_05v5 pj=5.36e+06 area=4.347e+11
+D0 VNB DIODE sky130_fd_pr__diode_pw2nd_05v5 pj=2.64e+06 area=4.347e+11
 .ends


### PR DESCRIPTION
The perimeter should be 2.64um (checked by measuring the perimeter in the layout).  The incorrect value undoubtedly came from an early extraction done with a faulty tech file for magic.