### PR TITLE
Fix typo in SLEEPB_delayed for lpflow_inputisolatch

### DIFF
--- a/cells/lpflow_inputisolatch/sky130_fd_sc_hd__lpflow_inputisolatch_1.timing.pp.v
+++ b/cells/lpflow_inputisolatch/sky130_fd_sc_hd__lpflow_inputisolatch_1.timing.pp.v
@@ -67,8 +67,8 @@ specify
 (posedge SLEEP_B => (Q +: D ) ) = (0:0:0,0:0:0); // delays are tris,tfall
 $width (posedge SLEEP_B , 0:0:0, 0, notifier);
 $width (negedge SLEEP_B , 0:0:0, 0, notifier);
-$setuphold ( negedge SLEEP_B , posedge D , 0:0:0, 0:0:0, notifier , , , SLEEPB_delayed , D_delayed ) ;
-$setuphold ( negedge SLEEP_B , negedge D , 0:0:0, 0:0:0, notifier , , , SLEEPB_delayed , D_delayed ) ;
+$setuphold ( negedge SLEEP_B , posedge D , 0:0:0, 0:0:0, notifier , , , SLEEP_B_delayed , D_delayed ) ;
+$setuphold ( negedge SLEEP_B , negedge D , 0:0:0, 0:0:0, notifier , , , SLEEP_B_delayed , D_delayed ) ;
 endspecify
 endmodule
 `endcelldefine

--- a/cells/lpflow_inputisolatch/sky130_fd_sc_hd__lpflow_inputisolatch_1.timing.v
+++ b/cells/lpflow_inputisolatch/sky130_fd_sc_hd__lpflow_inputisolatch_1.timing.v
@@ -65,8 +65,8 @@ specify
 (posedge SLEEP_B => (Q +: D ) ) = (0:0:0,0:0:0); // delays are tris,tfall
 $width (posedge SLEEP_B , 0:0:0, 0, notifier);
 $width (negedge SLEEP_B , 0:0:0, 0, notifier);
-$setuphold ( negedge SLEEP_B , posedge D , 0:0:0, 0:0:0, notifier , , , SLEEPB_delayed , D_delayed ) ;
-$setuphold ( negedge SLEEP_B , negedge D , 0:0:0, 0:0:0, notifier , , , SLEEPB_delayed , D_delayed ) ;
+$setuphold ( negedge SLEEP_B , posedge D , 0:0:0, 0:0:0, notifier , , , SLEEP_B_delayed , D_delayed ) ;
+$setuphold ( negedge SLEEP_B , negedge D , 0:0:0, 0:0:0, notifier , , , SLEEP_B_delayed , D_delayed ) ;
 endspecify
 endmodule
 `endcelldefine


### PR DESCRIPTION
In both timing files for `lpflow_inputisolatch` the `$setuphold` timing checks use the wrong signal. It is written as `SLEEPB_delayed` when it should be `SLEEP_B_delayed`.

Icarus Verilog only got upset now because I did not pass the toplevel module this time.