### PR TITLE
Changed the res_generic_po device in the conb cell SPICE netlist

### DIFF
--- a/cells/conb/sky130_fd_sc_hd__conb_1.spice
+++ b/cells/conb/sky130_fd_sc_hd__conb_1.spice
@@ -16,6 +16,6 @@
 
 
 .subckt sky130_fd_sc_hd__conb_1 VGND VNB VPB VPWR HI LO
-R0 VGND LO sky130_fd_pr__res_generic_po w=480000u l=45000u
-R1 HI VPWR sky130_fd_pr__res_generic_po w=480000u l=45000u
+XR0 VGND LO sky130_fd_pr__res_generic_po w=480000u l=45000u
+XR1 HI VPWR sky130_fd_pr__res_generic_po w=480000u l=45000u
 .ends


### PR DESCRIPTION
Changed the res_generic_po device in the conb cell SPICE netlist from an "R" component to an "X" subcircuit.  This supports the continuous/combined device models.